### PR TITLE
Typo in pip command

### DIFF
--- a/todoist/todoist_downloader.ipynb
+++ b/todoist/todoist_downloader.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "#### Download and Install Todoist Python Library\n",
     "\n",
-    "`$ pip install python-todoist`\n",
+    "`$ pip install todoist-python`\n",
     "\n",
     "#### Signup and Create a Todoist App\n",
     "\n",


### PR DESCRIPTION
According to the the [official PyPI documentation from Todoist](https://pypi.org/project/todoist-python/), the package name is `todoist-python`. Correcting it here.